### PR TITLE
[ESWE-1378] update api spec for 303 response

### DIFF
--- a/integration/integration-api-api-spec.yaml
+++ b/integration/integration-api-api-spec.yaml
@@ -82,6 +82,18 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/PersonResponse"
+        "303":
+          description: Redirect response when the provided HMPPS ID of the person is merged.
+          headers:
+            Location:
+              description: Redirect URL to the new person resource
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/responses/RedirectionResponse"
         "404":
           description: "Not Found"
           content:
@@ -158,6 +170,13 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/DataResponseOffenderSearchResponse"
+
+    RedirectionResponse:
+      description: Redirect response for person where the provided HMPPS ID has been merged.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OffenderSearchRedirectResponse"
 
   schemas:
     EducationAssessments:
@@ -265,6 +284,15 @@ components:
         data:
           $ref: "#/components/schemas/OffenderSearchResponse"
       required: [data]
+
+    OffenderSearchRedirectResponse:
+      properties:
+        prisonerNumber:
+          type: string
+        removedPrisonerNumber:
+          type: string
+      required: ["prisonerNumber", "removedPrisonerNumber"]
+
     OffenderSearchResponse:
       properties:
         prisonerOffenderSearch:


### PR DESCRIPTION

Updated spec for `/v1/persons/{encodedHmppsId}` endpoint for prisoner merge:

Http status: 303 (See Other)
Headers: Location header containing redirect url
Body: added schema `RedirectionResponse`
